### PR TITLE
Add some check to avoid someone modifying a Puppet module without bumpin...

### DIFF
--- a/puppetbuild.sh
+++ b/puppetbuild.sh
@@ -27,16 +27,24 @@ function build_puppetmodule {
             fi
             modarchive=${modname}-${modversion}.tar.gz
 
-            # build the archive
-            puppet module build ${MODULEDIR}
-            RETVAL=$?
-            if [[ ${RETVAL} != 0 ]]
+            if [ -f "${PUPPET_REPO}/${modarchive}" ]
             then
-                echo "Could not build puppet module ${modname} using ${METADATA}"
-                exit ${MODBUILD_ERR}
+                echo "WARNING: Puppet module '${modarchive}' already in repository," >&2
+                echo "         You might have forgotten to increase the version" >&2
+                echo "         after doing changes. Skipping ${MODULEFILE}" >&2
+            else
+
+                # build the archive
+                puppet module build ${MODULEDIR}
+                RETVAL=$?
+                if [[ ${RETVAL} != 0 ]]
+                then
+                    echo "Could not build puppet module ${modname} using ${METADATA}"
+                    exit ${MODBUILD_ERR}
+                fi
+                mv -nv ${MODULEDIR}/pkg/${modarchive} ${PUPPET_REPO} # don't overwrite
+                echo ${git_commit} > .puppetbuild-hash
             fi
-            mv ${MODULEDIR}/pkg/${modarchive} ${PUPPET_REPO}
-            echo ${git_commit} > .puppetbuild-hash
         else
             echo "No changes since last build - skipping ${METADATA}"
         fi

--- a/rpmpush.sh
+++ b/rpmpush.sh
@@ -18,11 +18,7 @@ then
     echo "PUSH_USER or SATELLITE not set or not found"
     exit ${WORKSPACE_ERR}
 fi
-    
-# scrub the srpms and mock build logs as they confuse satellite6
-rm -f ${YUM_REPO}/*.src.rpm
-rm -f ${YUM_REPO}/*.log
-    
+
 # refresh the upstream yum repo
 createrepo ${YUM_REPO}
     


### PR DESCRIPTION
Add some check to avoid someone modifying a Puppet module without bumping up the version and hence creating confusion.

Warning: the diff is a bit confusing because the indented lines (due to new if/then/else) are not properly matched to the corresponding non-indented lines, but actually only few lines to check existence of previously existing files have been added (+ -nv to mv command to not overwrite).