### PR TITLE
Avoid using the WORKSPACE variable to load common.sh, makes it more inde...

### DIFF
--- a/buildtestvms.sh
+++ b/buildtestvms.sh
@@ -6,8 +6,8 @@
 #
 # this will tell Foreman to rebuild all machines in hostgroup TESTVM_HOSTGROUP
 
-#
-. ${WORKSPACE}/scripts/common.sh
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 
 # rebuild test VMs

--- a/kickstartbuild.sh
+++ b/kickstartbuild.sh
@@ -5,7 +5,8 @@
 # e.g. ${WORKSPACE}/scripts/kickstartbuild.sh ${WORKSPACE}/soe/kickstarts/ 
 #
 
-. ${WORKSPACE}/scripts/common.sh
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 if [[ -z "$1" ]] || [[ ! -d "$1" ]]
 then

--- a/kickstartpush.sh
+++ b/kickstartpush.sh
@@ -4,7 +4,9 @@
 #
 # e.g. ${WORKSPACE}/scripts/kickstartpush.sh ${WORKSPACE}/artefacts/kickstarts/
 #
-. ${WORKSPACE}/scripts/common.sh
+
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 if [[ -z "$1" ]] || [[ ! -d "$1" ]]
 then

--- a/publishcv.sh
+++ b/publishcv.sh
@@ -2,7 +2,8 @@
 
 # Publish the content view and promote if necessary
 
-. ${WORKSPACE}/scripts/common.sh
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
     "hammer content-view publish --name \"${CV}\" --organization \"${ORG}\""

--- a/puppetbuild.sh
+++ b/puppetbuild.sh
@@ -5,7 +5,8 @@
 # e.g. ${WORKSPACE}/scripts/puppetbuilder.sh ${WORKSPACE}/soe/puppet/
 #
 
-. ${WORKSPACE}/scripts/common.sh
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 function build_puppetmodule {
 

--- a/puppetpush.sh
+++ b/puppetpush.sh
@@ -5,7 +5,8 @@
 # e.g. ${WORKSPACE}/scripts/puppetpush.sh 
 #
 
-. ${WORKSPACE}/scripts/common.sh
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]
 then

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -4,8 +4,9 @@
 #
 # e.g ${WORKSPACE}/scripts/pushtests.sh 'test'
 #
-. ${WORKSPACE}/scripts/common.sh
 
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 # get our test machines
 J=0

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -5,7 +5,8 @@
 # e.g. ${WORKSPACE}/scripts/rpmbuilder.sh ${WORKSPACE}/soe/rpms/ 
 #
 
-. ${WORKSPACE}/scripts/common.sh
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 function build_srpm {
     

--- a/rpmpush.sh
+++ b/rpmpush.sh
@@ -4,7 +4,9 @@
 #
 # e.g. ${WORKSPACE}/scripts/rpmpush.sh ${WORKSPACE}/soe/artefacts/
 #
-. ${WORKSPACE}/scripts/common.sh
+
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
 
 if [[ -z "$1" ]] || [[ ! -d "$1" ]]
 then


### PR DESCRIPTION
...pendent from Jenkins, and it makes also easier to do some simple local tests. There is more to do, I would suggest to get rid altogether of the WORKSPACE variable within scripts, this is just a first step.