### PR TITLE
reboot only works for running hosts, we have to start the shutoff ones

### DIFF
--- a/buildtestvms.sh
+++ b/buildtestvms.sh
@@ -18,8 +18,20 @@ do
     echo "Rebuilding VM ID $I"
     ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
         "hammer host update --id $I --build yes"
-    ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
-        "hammer host reboot --id $I"
+
+    _STATUS=$(ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} "hammer host status --id $I" | grep Power | cut -f2 -d: | tr -d ' ')
+    if [[ ${_STATUS} == 'running' ]]
+    then
+        ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+            "hammer host reboot --id $I"
+    elif [[ ${_STATUS} == 'shutoff' ]]
+    then
+        ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+            "hammer host start --id $I"
+    else
+        echo "Host $I is neither running nor shutoff. No action possible!"
+        exit 1
+    fi
 done
 
 


### PR DESCRIPTION
When a host that should be rebuilt is shut off, "hammer host reboot" will fail with an missleading message:

    Call to virDomainReboot failed: Requested operation is not valid: Reboot is not supported without the JSON monitor

While I think this is a bug in the libvirt API -- a reboot of a shut off domain should just boot it, as it happens with services all the time -- we can and should just fix it in our scripts.

This commit checks the status of the host and acts accordingly, depending on the result (running → reboot, shutoff → start).