### PR TITLE
Whole bunch of small fixes - array quotes, IFS, kickstartbuild, Jenkins config

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -208,7 +208,7 @@ echo &quot;#####################################################&quot;
       <failedTestsMarkBuildAsFailure>false</failedTestsMarkBuildAsFailure>
       <outputTapToConsole>false</outputTapToConsole>
       <enableSubtests>false</enableSubtests>
-      <discardOldReports>false</discardOldReports>
+      <discardOldReports>true</discardOldReports>
       <todoIsFailure>false</todoIsFailure>
       <includeCommentDiagnostics>false</includeCommentDiagnostics>
       <validateNumberOfTests>false</validateNumberOfTests>

--- a/kickstartbuild.sh
+++ b/kickstartbuild.sh
@@ -10,22 +10,20 @@
 
 if [[ -z "$1" ]] || [[ ! -d "$1" ]]
 then
-    usage "$0 <directory containing puppet module directories>"
+    usage "$0 <directory containing kickstart files>"
     exit ${NOARGS}
 fi
 workdir=$1
 
 if [[ -z ${WORKSPACE} ]] || [[ ! -w ${WORKSPACE} ]]
 then
-    err "WORKSPACE not set or not found"
+    err "Environment variable 'WORKSPACE' not set or not found"
     exit ${WORKSPACE_ERR}
 fi
 
 # setup artefacts environment 
 ARTEFACTS=${WORKSPACE}/artefacts/kickstarts
-rm -f ${ARTEFACTS}/*.erb
-mkdir -p ${ARTEFACTS}
 
-cp ${workdir}/*.erb ${ARTEFACTS}
-
-
+# copy erb files from one directory to the next, creating directory if needed
+rsync -tdv --delete-excluded --include=*.erb --exclude=* \
+	"${workdir}/" "${ARTEFACTS}"

--- a/publishcv.sh
+++ b/publishcv.sh
@@ -51,7 +51,7 @@ then # we want to update and publish all CCVs containing our CVs
     # We need at the same time to find out which of the CCVs use the given CV
     # as well as keep the ID of all other used CV versions, but filter out
     # the currently used version of our CV, to avoid two versions of the same CV
-    for ccv_id in ${CCV_TMP_IDS[@]}
+    for ccv_id in "${CCV_TMP_IDS[@]}"
     do
 	cv_tmp_ver_ids=$(ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
             "hammer --output yaml content-view info --id ${ccv_id} --organization \"${ORG}\"" \

--- a/publishcv.sh
+++ b/publishcv.sh
@@ -12,8 +12,17 @@
 . $(dirname "${0}")/common.sh
 
 # Create an array from all the content view names
-IFS=',' CV_LIST=( ${CV} ${CV_PASSIVE_LIST} )
+oldIFS="${IFS}"
+i=0
+IFS=','
+for cv in ${CV} ${CV_PASSIVE_LIST}
+do
+        CV_LIST[$i]="${cv}"
+        ((i++))
+done
+IFS="${oldIFS}"
 
+# Get a list of all CV version IDs
 for cv in "${CV_LIST[@]}"
 do
     ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \


### PR DESCRIPTION
Whole bunch of small fixes:
* messed a bit with IFS and needed a slightly more complicated approach.
* forgot to put double quotes around an `${array[@]}` construct.
* fix kickstartbuild to align it with other artefact build scripts
* small fix in Jenkins' config.xml so that old test reports are ignored by the TAP plugin