### PR TITLE
SOE-CI selective build

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
     * Git Plugin
     * Multiple SCMs Plugin
     * TAP Plugin
+    * Post-Build Script Plug-in
 * Restart Jenkins
 * Add the `jenkins` user to the `mock` group. This will allow Jenkins to build RPMs.
 * Create `/var/www/html/pub/soe-repo` and `/var/www/html/pub/soe-puppet` and assign their ownership to the `jenkins` user. These will be used as the upstream repositories to publish artefacts to the satellite.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Now manually trigger a build on Jenkins. This will fail, however it will create 
 * Create an activation key that provides access to the RHEL 7 RPMs, RHEL 7 Common, RPMS, and Puppet repos. (you don't need access to the kickstart repo after installation)
 * Create a hostgroup (I called mine 'Test Servers') that deploys machines on to the Compute Resource that you configured earlier, and uses the activation key that you created. Create a default root password and make a note of it. 
 * Create a couple of initial test servers and deploy them. Ensure that they can see your private RPM and puppet repositories.
-
+    * If you plan to use the conditional VM build feature, edit the comment field of your test host(s) with the names of the Puppet modules, RPM packages and/or kickstart files surrounded by '#' if they are relevant to be tested on this specific host. E.g. if the 'ssh' module is modified, a host will only be re-built and tested if its comment field contains the string '#ssh#'. 
 
 ### Getting Started
 At this point, you should be good to go. In fact Jenkins may have already kicked off a build for you when you pushed common.sh.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
 * Do an initial sync
 * Create a product called 'ACME SOE'
 * Create a puppet repository called 'Puppet' with an upstream repo of http://jenkinsserver/pub/soe-puppet
-* Create an RPM repository called 'RPMs' with an upstream repo of http://jenkinsserver/pub/soe-ci
+* Create an RPM repository called 'RPMs' with an upstream repo of http://jenkinsserver/pub/soe-repo
 * Do NOT create a sync plan for the ACME SOE product. This will be synced by Jenkins when needed.
 * Take a note of the repo IDs for the Puppet and RPMs repos. You can find these by hovering over the repository names in the Products view on the Repositories tab. The digits at the end of the URL are the repo IDs.
 * Configure hammer for passwordless usage by creating a `/etc/hammer/cli_config.yml` file. [More details here](http://blog.theforeman.org/2013/11/hammer-cli-for-foreman-part-i-setup.html).

--- a/buildtestvms.sh
+++ b/buildtestvms.sh
@@ -17,11 +17,10 @@ then
     exit ${WORKSPACE_ERR}
 fi
 
+get_test_vm_list # populate TEST_VM_LIST
+
 # rebuild test VMs
-for I in $(ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
-        "hammer content-host list --organization \"${ORG}\" \
-		--host-collection \"$TESTVM_HOSTCOLLECTION\" \
-            | tail -n +4 | cut -f2 -d \"|\" | head -n -1")
+for I in "${TEST_VM_LIST[@]}"
 do
     info "Rebuilding VM ID $I"
     ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash 
+
+# Clean-up the Jenkins Workspace after a successful build
+#
+# e.g. ${WORKSPACE}/scripts/cleanup.sh
+#
+
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
+
+if [[ ! -n "${WORKSPACE}" || ! -d "${WORKSPACE}" ]]
+then
+    err "Variable 'WORKSPACE' undefined or set to non existing '${WORKSPACE}'."
+    exit ${WORKSPACE_ERR}
+fi
+
+# We delete the list of modified contents only once a build has been
+# successful, or we might not test all changes done.
+# If a build is unstable, the failed test(s) should at least tell us which
+# content needs amendment.
+rm -fv "${MODIFIED_CONTENT_FILE}"
+

--- a/common.sh
+++ b/common.sh
@@ -45,7 +45,10 @@ function get_test_vm_list() {
 	do
 		# If CONDITIONAL_VM_BUILD is 'true', only keep VMs commented
 		# with modified #content# as listed in $MODIFIED_CONTENT_FILE
+		# If the file is empty or doesn't exist, we test everything
+		# as it hints at a script change.
 		if [[ "${CONDITIONAL_VM_BUILD}" != 'true' ]] || \
+			[[ ! -s "${MODIFIED_CONTENT_FILE} ]] || \
 			ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
 			"hammer --output yaml host info --name \"${I}\"" \
 				| grep "^Comment:" \

--- a/common.sh
+++ b/common.sh
@@ -43,10 +43,16 @@ function get_test_vm_list() {
 			--host-collection \"$TESTVM_HOSTCOLLECTION\" \
 		| tail -n +4 | cut -f2 -d \"|\" | head -n -1")
 	do
-		# TODO add a test on CONDITIONAL_VM_BUILD == 'true' to only
-		#      keep VMs commented with modified #content# as listed
-		#      in "${MODIFIED_CONTENT_FILE}"
-		TEST_VM_LIST[$J]=$I
-		((J+=1))
+		# If CONDITIONAL_VM_BUILD is 'true', only keep VMs commented
+		# with modified #content# as listed in $MODIFIED_CONTENT_FILE
+		if [[ "${CONDITIONAL_VM_BUILD}" != 'true' ]] || \
+			ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+			"hammer --output yaml host info --name \"${I}\"" \
+				| grep "^Comment:" \
+				| grep -Fqf "${MODIFIED_CONTENT_FILE}"
+		then
+			TEST_VM_LIST[$J]=$I
+			((J+=1))
+		fi
 	done
 }

--- a/common.sh
+++ b/common.sh
@@ -48,7 +48,7 @@ function get_test_vm_list() {
 		# If the file is empty or doesn't exist, we test everything
 		# as it hints at a script change.
 		if [[ "${CONDITIONAL_VM_BUILD}" != 'true' ]] || \
-			[[ ! -s "${MODIFIED_CONTENT_FILE} ]] || \
+			[[ ! -s "${MODIFIED_CONTENT_FILE}" ]] || \
 			ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
 			"hammer --output yaml host info --name \"${I}\"" \
 				| grep "^Comment:" \

--- a/common.sh
+++ b/common.sh
@@ -30,3 +30,23 @@ function warn() {
 function err() {
 	tell "ERROR:   ${@}" >&2
 }
+
+# Name of file where modified content artefacts are being tracked
+# This approach (and file) is only used if CONDITIONAL_VM_BUILD is 'true'
+MODIFIED_CONTENT_FILE=${WORKSPACE}/modified_content.track
+
+# get our test machines into an array variable TEST_VM_LIST
+function get_test_vm_list() {
+	local J=0
+	for I in $(ssh -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+		"hammer content-host list --organization \"${ORG}\" \
+			--host-collection \"$TESTVM_HOSTCOLLECTION\" \
+		| tail -n +4 | cut -f2 -d \"|\" | head -n -1")
+	do
+		# TODO add a test on CONDITIONAL_VM_BUILD == 'true' to only
+		#      keep VMs commented with modified #content# as listed
+		#      in "${MODIFIED_CONTENT_FILE}"
+		TEST_VM_LIST[$J]=$I
+		((J+=1))
+	done
+}

--- a/config.xml
+++ b/config.xml
@@ -92,6 +92,18 @@ CCVs respecting the pattern but not containing any CV will not be touched.
 Example of pattern: &quot;ccv-test-*&quot;</description>
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>CONDITIONAL_VM_BUILD</name>
+          <description>If this parameter is true/set, only the hosts existing in Satellite with a comment matching
+the modified Puppet module, RPM package or kickstart file, each surrounded by hashes (#), will be built and tested.
+&lt;br/&gt;
+Examples: &lt;code&gt;#ssh#bats#kickstart.erb#&lt;/code&gt;
+&lt;br/&gt;
+&lt;b&gt;CAUTION:&lt;/b&gt; be aware that in this case, no host will be tested if only the scripts have been modified.
+&lt;br/&gt;
+If unset/false, all existing hosts, within the given Host Collection, will be rebuilt independent of changes done in Git.</description>
+          <defaultValue>false</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>

--- a/config.xml
+++ b/config.xml
@@ -227,6 +227,19 @@ echo &quot;#####################################################&quot;
       <planRequired>true</planRequired>
       <verbose>true</verbose>
     </org.tap4j.plugin.TapPublisher>
+    <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@0.17">
+      <buildSteps>
+        <hudson.tasks.Shell>
+          <command>echo &quot;#####################################################&quot;
+echo &quot;#          CLEAN-UP AFTER SUCCESS BUILD             #&quot;
+echo &quot;#####################################################&quot;
+/bin/bash -x ${WORKSPACE}/scripts/cleanup.sh</command>
+        </hudson.tasks.Shell>
+      </buildSteps>
+      <scriptOnlyIfSuccess>true</scriptOnlyIfSuccess>
+      <scriptOnlyIfFailure>false</scriptOnlyIfFailure>
+      <markBuildUnstable>false</markBuildUnstable>
+    </org.jenkinsci.plugins.postbuildscript.PostBuildScript>
   </publishers>
   <buildWrappers/>
 </project>

--- a/kickstartbuild.sh
+++ b/kickstartbuild.sh
@@ -21,9 +21,10 @@ then
     exit ${WORKSPACE_ERR}
 fi
 
-# setup artefacts environment 
+# setup artefacts environment
 ARTEFACTS=${WORKSPACE}/artefacts/kickstarts
 
 # copy erb files from one directory to the next, creating directory if needed
-rsync -tdv --delete-excluded --include=*.erb --exclude=* \
-	"${workdir}/" "${ARTEFACTS}"
+rsync -td --out-format="#%n#" --delete-excluded --include=*.erb --exclude=* \
+	"${workdir}/" "${ARTEFACTS}" \
+	| grep -e '\.erb#$' | tee -a "${MODIFIED_CONTENT_FILE}"

--- a/puppetbuild.sh
+++ b/puppetbuild.sh
@@ -45,7 +45,9 @@ function build_puppetmodule {
                 fi
                 mv -nv ${MODULEDIR}/pkg/${modarchive} ${PUPPET_REPO} # don't overwrite
             fi
+            # Something has changed, track it for build and for tests
             echo ${git_commit} > .puppetbuild-hash
+            echo "#${modname}#" >> "${MODIFIED_CONTENT_FILE}"
         else
             info "No changes since last build - skipping ${METADATA}"
         fi

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -40,7 +40,9 @@ function build_srpm {
                      "You might have forgotten to increase the version" \
                      "after doing changes. Skipping ${SPECFILE}"
             fi
+            # Something has changed, track it for build and for tests
             echo ${git_commit} > .rpmbuild-hash
+            echo "#${rpmname}#" >> "${MODIFIED_CONTENT_FILE}"
         else
             info "No changes since last build - skipping ${SPECFILE}"
         fi


### PR DESCRIPTION
The instructions in the README.md probably explains it best:

> If you plan to use the conditional VM build feature, edit the comment field of your test host(s) with the names of the Puppet modules, RPM packages and/or kickstart files surrounded by '#' if they are relevant to be tested on this specific host. E.g. if the 'ssh' module is modified, a host will only be re-built and tested if its comment field contains the string '#ssh#'.

This required addition of a cleanup(.sh) step as well, implying usage of a new Jenkins plug-in.

The changes should be backward compatible.