### PR TITLE
removed offline option as we want mock to pull from Satellite6

### DIFF
--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -18,7 +18,7 @@ function build_srpm {
             # determine the name of the rpm from the specfile
             rpmname=$(IGNORECASE=1 awk '/^Name:/ {print $2}' ${SPECFILE})
             rm -f ${SRPMS_DIR}/${rpmname}-*.src.rpm
-            /usr/bin/mock --offline --buildsrpm --spec ${SPECFILE} --sources $(pwd) --resultdir ${SRPMS_DIR}
+            /usr/bin/mock  --buildsrpm --spec ${SPECFILE} --sources $(pwd) --resultdir ${SRPMS_DIR}
             RETVAL=$?
             if [[ ${RETVAL} != 0 ]]
             then
@@ -26,7 +26,7 @@ function build_srpm {
                 exit ${SRPMBUILD_ERR}
             fi
             srpmname=${SRPMS_DIR}/${rpmname}-*.src.rpm
-            /usr/bin/mock --offline --rebuild ${srpmname} -D "%debug_package %{nil}" --resultdir ${RPMS_DIR}
+            /usr/bin/mock  --rebuild ${srpmname} -D "%debug_package %{nil}" --resultdir ${RPMS_DIR}
             RETVAL=$?
             if [[ ${RETVAL} != 0 ]]
             then


### PR DESCRIPTION
EricL,
I had to remove the --offline option for mock builds (so far only el7 tested) to work.
Please verify I got this right and if I did merge.
PCFE