### PR TITLE
allow spaces in Jenkins job names. [addresses #80]

### DIFF
--- a/buildtestvms.sh
+++ b/buildtestvms.sh
@@ -6,8 +6,10 @@
 #
 # this will tell Foreman to rebuild all machines in hostgroup TESTVM_HOSTGROUP
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]  || [[ -z ${RSA_ID} ]] \
    || [[ -z ${ORG} ]] || [[ -z ${TESTVM_HOSTCOLLECTION} ]]

--- a/capsule-sync-check.sh
+++ b/capsule-sync-check.sh
@@ -3,8 +3,10 @@
 # While a Capsule Sync is in progress, we must wait
 # as the System Under Test (SUT) may be behind a Capsule
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]  || [[ -z ${RSA_ID} ]] \
    || [[ -z ${ORG} ]] || [[ -z ${TESTVM_HOSTCOLLECTION} ]]

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -5,8 +5,10 @@
 # e.g. ${WORKSPACE}/scripts/cleanup.sh
 #
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 if [[ ! -n "${WORKSPACE}" || ! -d "${WORKSPACE}" ]]
 then

--- a/common.sh
+++ b/common.sh
@@ -12,7 +12,7 @@ SRPMBUILD_ERR=6
 MODBUILD_ERR=7
 
 function tell() {
-	echo "${@} [$(date)]" | fold -s
+	echo "${@} [$(date)]"
 }
 
 function inform() {

--- a/common.sh
+++ b/common.sh
@@ -12,7 +12,7 @@ SRPMBUILD_ERR=6
 MODBUILD_ERR=7
 
 function tell() {
-	echo "${@} [$(date)]"
+	echo "${@} [$(date)]" | fold --spaces --width=240
 }
 
 function inform() {

--- a/config.xml
+++ b/config.xml
@@ -102,16 +102,23 @@ If unset/false, all existing hosts, within the given Host Collection, will be re
         <hudson.model.StringParameterDefinition>
           <name>MOCK_CONFIG</name>
           <description>This will be passed to mock --root
-e.g. mock --root rhel-6-x86_64
+e.g. mock --root rhel-7-x86_64
 needed to ensure we can build RPMs against more then just the default mock chroot.</description>
-          <defaultValue>rhel-6-x86_64</defaultValue>
+          <defaultValue>rhel-7-x86_64</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PUPPET_DONE_SLEEP</name>
+          <description>Number of seconds to wait in puppet-done-test.sh
+if you set up things with puppet that take a while to settle (e.g. NTP), you may want to wait a bit (e.g. 75 seconds
+ is good for ntp to settle)</description>
+          <defaultValue>75</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="org.jenkinsci.plugins.multiplescms.MultiSCM" plugin="multiple-scms@0.3">
+  <scm class="org.jenkinsci.plugins.multiplescms.MultiSCM" plugin="multiple-scms@0.6">
     <scms>
-      <hudson.plugins.git.GitSCM plugin="git@2.2.7">
+      <hudson.plugins.git.GitSCM plugin="git@3.5.1">
         <configVersion>2</configVersion>
         <userRemoteConfigs>
           <hudson.plugins.git.UserRemoteConfig>
@@ -131,7 +138,7 @@ needed to ensure we can build RPMs against more then just the default mock chroo
           </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
         </extensions>
       </hudson.plugins.git.GitSCM>
-      <hudson.plugins.git.GitSCM plugin="git@2.2.7">
+      <hudson.plugins.git.GitSCM plugin="git@3.5.1">
         <configVersion>2</configVersion>
         <userRemoteConfigs>
           <hudson.plugins.git.UserRemoteConfig>
@@ -157,62 +164,70 @@ needed to ensure we can build RPMs against more then just the default mock chroo
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers>
-    <hudson.triggers.SCMTrigger>
-      <spec>* * * * * </spec>
-      <ignorePostCommitHooks>false</ignorePostCommitHooks>
-    </hudson.triggers.SCMTrigger>
-  </triggers>
+  <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
+      <command>#!/bin/bash
+
+echo &quot;#####################################################&quot;
 echo &quot;#                BUILDING RPMS                      #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/rpmbuild.sh ${WORKSPACE}/soe/rpms
+&quot;${WORKSPACE}/scripts/rpmbuild.sh&quot; &quot;${WORKSPACE}/soe/rpms&quot;
 
 echo &quot;#####################################################&quot;
 echo &quot;#                BUILDING PUPPET MODULES            #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/puppetbuild.sh ${WORKSPACE}/soe/puppet
+&quot;${WORKSPACE}/scripts/puppetbuild.sh&quot; &quot;${WORKSPACE}/soe/puppet&quot;
 
 echo &quot;#####################################################&quot;
 echo &quot;#                BUILDING KICKSTARTS                #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/kickstartbuild.sh ${WORKSPACE}/soe/kickstarts
-</command>
+&quot;${WORKSPACE}/scripts/kickstartbuild.sh&quot; &quot;${WORKSPACE}/soe/kickstarts&quot;</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
+      <command>#!/bin/bash
+
+echo &quot;#####################################################&quot;
 echo &quot;#                PUSH RPMS TO SATELLITE             #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/rpmpush.sh ${WORKSPACE}/artefacts
+&quot;${WORKSPACE}/scripts/rpmpush.sh&quot; &quot;${WORKSPACE}/artefacts&quot;
+
 echo &quot;#####################################################&quot;
 echo &quot;#         PUSH PUPPET MODULES TO SATELLITE          #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/puppetpush.sh ${WORKSPACE}/artefacts
+&quot;${WORKSPACE}/scripts/puppetpush.sh&quot; &quot;${WORKSPACE}/artefacts&quot;
+
 echo &quot;#####################################################&quot;
 echo &quot;#           PUSH KICKSTARTS TO SATELLITE            #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/kickstartpush.sh ${WORKSPACE}/artefacts
+&quot;${WORKSPACE}/scripts/kickstartpush.sh&quot; &quot;${WORKSPACE}/artefacts&quot;
+
 echo &quot;#####################################################&quot;
 echo &quot;#           REPUBLISH CONTENT VIEW                  #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/publishcv.sh</command>
+&quot;${WORKSPACE}/scripts/publishcv.sh&quot;
+
+echo &quot;#####################################################&quot;
+echo &quot;#           WAIT FOR CAPSULE SYNC                   #&quot;
+echo &quot;#####################################################&quot;
+&quot;${WORKSPACE}/scripts/capsule-sync-check.sh&quot;</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
+      <command>#!/bin/bash
+
+echo &quot;#####################################################&quot;
 echo &quot;#                REBUILDING TEST VMS                #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/buildtestvms.sh
-</command>
+&quot;${WORKSPACE}/scripts/buildtestvms.sh&quot;</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
+      <command>#!/bin/bash
+
+echo &quot;#####################################################&quot;
 echo &quot;#            PUSHING TESTS to TEST VMS              #&quot;
 echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/pushtests.sh
-</command>
+&quot;${WORKSPACE}/scripts/pushtests.sh&quot;</command>
     </hudson.tasks.Shell>
     <org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.3.6">
       <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.0">
@@ -230,17 +245,23 @@ echo &quot;#####################################################&quot;
         </bestResult>
       </condition>
       <buildStep class="hudson.tasks.Shell">
-        <command>echo &quot;#####################################################&quot;
-  echo &quot;#          CLEAN-UP AFTER SUCCESS BUILD             #&quot;
-  echo &quot;#####################################################&quot;
-  /bin/bash -x ${WORKSPACE}/scripts/cleanup.sh
-  </command>
+        <command>#!/bin/bash
+
+echo &quot;#####################################################&quot;
+echo &quot;#               POWER OFF TEST VMs                  #&quot;
+echo &quot;#####################################################&quot;
+&quot;${WORKSPACE}/scripts/powerofftestvms.sh&quot;
+
+echo &quot;#####################################################&quot;
+echo &quot;#          CLEAN-UP AFTER SUCCESS BUILD             #&quot;
+echo &quot;#####################################################&quot;
+&quot;${WORKSPACE}/scripts/cleanup.sh&quot;</command>
       </buildStep>
       <runner class="org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail" plugin="run-condition@1.0"/>
     </org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder>
   </builders>
   <publishers>
-    <org.tap4j.plugin.TapPublisher plugin="tap@1.20">
+    <org.tap4j.plugin.TapPublisher plugin="tap@2.1">
       <testResults>test_results/*.tap</testResults>
       <failIfNoResults>false</failIfNoResults>
       <failedTestsMarkBuildAsFailure>false</failedTestsMarkBuildAsFailure>
@@ -252,7 +273,16 @@ echo &quot;#####################################################&quot;
       <validateNumberOfTests>false</validateNumberOfTests>
       <planRequired>true</planRequired>
       <verbose>true</verbose>
+      <showOnlyFailures>false</showOnlyFailures>
+      <stripSingleParents>false</stripSingleParents>
+      <flattenTapResult>false</flattenTapResult>
+      <skipIfBuildNotOk>false</skipIfBuildNotOk>
     </org.tap4j.plugin.TapPublisher>
+    <hudson.tasks.Mailer plugin="mailer@1.20">
+      <recipients>pcfe@pcfe.net</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
   </publishers>
   <buildWrappers/>
 </project>

--- a/kickstartbuild.sh
+++ b/kickstartbuild.sh
@@ -5,15 +5,32 @@
 # e.g. ${WORKSPACE}/scripts/kickstartbuild.sh ${WORKSPACE}/soe/kickstarts/ 
 #
 
-# Load common parameter variables
-. $(dirname "${0}")/common.sh
+#set -x
 
-if [[ -z "$1" ]] || [[ ! -d "$1" ]]
+# Load common parameter variables
+source scripts/common.sh
+
+printf -v escaped_1 %q "${1}"
+
+if [[ -z ${escaped_1} ]]
 then
     usage "$0 <directory containing kickstart files>"
+    warn "the test zero length failed for ${escaped_1}"
+    warn "you used $0 $@"
     exit ${NOARGS}
 fi
+
+if [[ ! -d "${1}" ]]
+then
+    usage "$0 <directory containing kickstart files>"
+    warn "the test directory exists failed for ${escaped_1}"
+    warn "you used $0 $@"
+    exit ${NOARGS}
+fi
+
 workdir=$1
+printf -v escaped_workdir %q "${1}"
+printf -v escaped_WORKSPACE %q "${WORKSPACE}"
 
 if [[ -z ${WORKSPACE} ]] || [[ ! -w ${WORKSPACE} ]]
 then
@@ -22,8 +39,8 @@ then
 fi
 
 # setup artefacts environment
-ARTEFACTS=${WORKSPACE}/artefacts/kickstarts
-mkdir -p $ARTEFACTS
+ARTEFACTS="${WORKSPACE}/artefacts/kickstarts"
+mkdir -p "${ARTEFACTS}"
 
 # copy erb files from one directory to the next, creating directory if needed
 rsync -td --out-format="#%n#" --delete-excluded --include=*.erb --exclude=* \

--- a/kickstartbuild.sh
+++ b/kickstartbuild.sh
@@ -23,7 +23,7 @@ fi
 if [[ ! -d "${1}" ]]
 then
     usage "$0 <directory containing kickstart files>"
-    warn "the test directory exists failed for ${escaped_1}"
+    warn "the test directory exists failed for ${1}"
     warn "you used $0 $@"
     exit ${NOARGS}
 fi

--- a/kickstartpush.sh
+++ b/kickstartpush.sh
@@ -23,7 +23,7 @@ fi
 if [[ ! -d "${1}" ]]
 then
     usage "$0 <kickstarts directory>"
-    warn "the test directory exists failed for ${escaped_1}"
+    warn "the test directory exists failed for ${1}"
     warn "you used $0 $@"
     exit ${NOARGS}
 fi

--- a/powerofftestvms.sh
+++ b/powerofftestvms.sh
@@ -6,8 +6,10 @@
 # e.g ${WORKSPACE}/scripts/powerofftestvms.sh 'test'
 #
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]  || [[ -z ${RSA_ID} ]] \
    || [[ -z ${ORG} ]] || [[ -z ${TESTVM_HOSTCOLLECTION} ]]

--- a/publishcv.sh
+++ b/publishcv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Publish the content view(s) and promote if necessary
 #
@@ -8,8 +8,10 @@
 #   CV_PASSIVE_LIST="cv-passive-1,cv-passive-2" ORG=Default_Organization \
 #   CCV_NAME_PATTERN="ccv-test-*" BUILD_URL=$$ ./publishcv.sh
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 # has anything changed? If yes, then MODIFIED_CONTENT_FILE is not 0 bytes 
 if [[ ! -s "${MODIFIED_CONTENT_FILE}" ]]

--- a/puppetbuild.sh
+++ b/puppetbuild.sh
@@ -72,7 +72,7 @@ fi
 if [[ ! -d "${1}" ]]
 then
     usage "$0 <directory containing puppet module directories>"
-    warn "the test directory exists failed for ${escaped_1}"
+    warn "the test directory exists failed for ${1}"
     warn "you used $0 $@"
     exit ${NOARGS}
 fi

--- a/puppetpush.sh
+++ b/puppetpush.sh
@@ -6,7 +6,7 @@
 #
 
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]
 then

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -1,12 +1,14 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Push BATS tests to test VMs
 #
 # e.g ${WORKSPACE}/scripts/pushtests.sh 'test'
 #
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 get_test_vm_list # populate TEST_VM_LIST
 
@@ -99,7 +101,7 @@ do
 done
 
 # execute the tests in parallel on all test servers
-mkdir -p ${WORKSPACE}/test_results
+mkdir -p "${WORKSPACE}/test_results"
 for I in ${TEST_VM_LIST[@]}
 do
     inform "Starting TAPS tests on test server $I"

--- a/r10kdeploy.sh
+++ b/r10kdeploy.sh
@@ -5,8 +5,8 @@
 # e.g. ${WORKSPACE}/scripts/r10kdeploy.sh
 #
  
-. $(dirname "${0}")/common.sh
- 
+source scripts/common.sh
+
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]] || [[ -z ${R10K_USER} ]]
 then
     err "PUSH_USER, R10K_USER or SATELLITE not set or not found"

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -77,7 +77,7 @@ fi
 if [[ ! -d "${1}" ]]
 then
     usage "$0 <directory containing RPM source directories>"
-    warn "the test directory exists failed for ${escaped_1}"
+    warn "the test directory exists failed for ${1}"
     warn "you used $0 $@"
     exit ${NOARGS}
 fi

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -5,35 +5,50 @@
 # e.g. ${WORKSPACE}/scripts/rpmbuilder.sh ${WORKSPACE}/soe/rpms/ 
 #
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
+
+printf -v escaped_1 %q "${1}"
 
 function build_srpm {
     
     if [[ -e "$1" ]]
     then
-        git_commit=$(git log --format="%H" -1  $(pwd))
+        git_commit=$(git log --format="%H" -1  .)
         if  [[ ! -e .rpmbuild-hash ]] || [[ ${git_commit} != $(cat .rpmbuild-hash) ]]
         then
             # determine the name of the rpm from the specfile
             rpmname=$(IGNORECASE=1 awk '/^Name:/ {print $2}' ${SPECFILE})
-            rm -f ${SRPMS_DIR}/${rpmname}-*.src.rpm
-            /usr/bin/mock --buildsrpm --spec ${SPECFILE} --sources $(pwd) --resultdir ${SRPMS_DIR} --root ${MOCK_CONFIG}
+            rm -f "${SRPMS_DIR}/${rpmname}-*.src.rpm"
+            /usr/bin/mock --buildsrpm --spec "${SPECFILE}" --sources "$(pwd)" --resultdir "${SRPMS_DIR}" --root ${MOCK_CONFIG}
             RETVAL=$?
             if [[ ${RETVAL} != 0 ]]
             then
                 err "Could not build SRPM ${rpmname} using the specfile ${SPECFILE}"
                 exit ${SRPMBUILD_ERR}
             fi
-            srpmname=${SRPMS_DIR}/${rpmname}-*.src.rpm
-            /usr/bin/mock --rebuild ${srpmname} -D "%debug_package %{nil}" --resultdir ${RPMS_DIR} --root ${MOCK_CONFIG}
+
+            pushd "${WORKSPACE}"
+            # printf -v srpmrelpath %q "$(find tmp/srpms -name ${rpmname}*)"
+            srpmrelpath="$(find tmp/srpms -name ${rpmname}*)"
+            popd
+
+            #srpmname="${WORKSPACE}/${srpmrelpath}"
+            printf -v srpmname_escaped %q "${WORKSPACE}/${srpmrelpath}"
+            srpmname="${WORKSPACE}/${srpmrelpath}"
+
+            /usr/bin/mock --rebuild "${srpmname}" -D "%debug_package %{nil}" --resultdir "${RPMS_DIR}" --root ${MOCK_CONFIG}
             RETVAL=$?
             if [[ ${RETVAL} != 0 ]]
             then
                 err "Could not build RPM ${rpmname} from ${srpmname}"
                 exit ${RPMBUILD_ERR}
             fi
-            mv -nv ${RPMS_DIR}/*.rpm ${YUM_REPO} # don't overwrite RPMs
+            pushd "${RPMS_DIR}"
+            mv -nv *.rpm ${YUM_REPO} # don't overwrite RPMs
+            popd
             restorecon -F ${YUM_REPO}/*.rpm
             if [ "$(echo ${RPMS_DIR}/*.rpm)" != "${RPMS_DIR}/*.rpm" ]
             then # not all RPM files could be moved, some are remaining
@@ -51,12 +66,24 @@ function build_srpm {
     fi
 }
 
-if [[ -z "$1" ]] || [[ ! -d "$1" ]]
+if [[ -z ${escaped_1} ]]
 then
     usage "$0 <directory containing RPM source directories>"
+    warn "the test zero length failed for ${escaped_1}"
+    warn "you used $0 $@"
     exit ${NOARGS}
 fi
+
+if [[ ! -d "${1}" ]]
+then
+    usage "$0 <directory containing RPM source directories>"
+    warn "the test directory exists failed for ${escaped_1}"
+    warn "you used $0 $@"
+    exit ${NOARGS}
+fi
+
 workdir=$1
+printf -v escaped_workdir %q "${1}"
 
 if [[ -z ${WORKSPACE} ]] || [[ ! -w ${WORKSPACE} ]]
 then
@@ -64,12 +91,12 @@ then
     exit ${WORKSPACE_ERR}
 fi
 
-SRPMS_DIR=${WORKSPACE}/tmp/srpms
-RPMS_DIR=${WORKSPACE}/tmp/rpms
-mkdir -p ${SRPMS_DIR} ${RPMS_DIR}
+SRPMS_DIR="${WORKSPACE}/tmp/srpms"
+RPMS_DIR="${WORKSPACE}/tmp/rpms"
+mkdir -p "${SRPMS_DIR}" "${RPMS_DIR}"
 
 # Traverse directories looking for spec files and build SRPMs
-cd ${workdir}
+cd "${workdir}"
 for I in $( ls -d */ )
 do
     SPECFILE=""
@@ -80,4 +107,3 @@ do
     popd
 done
 wait # TODO: add comment to explain why this?
-

--- a/rpmpush.sh
+++ b/rpmpush.sh
@@ -5,8 +5,10 @@
 # e.g. ${WORKSPACE}/scripts/rpmpush.sh ${WORKSPACE}/soe/artefacts/
 #
 
+#set -x
+
 # Load common parameter variables
-. $(dirname "${0}")/common.sh
+source scripts/common.sh
 
 # has anything changed? If yes, then MODIFIED_CONTENT_FILE is not 0 bytes 
 if [[ ! -s "${MODIFIED_RPMS_FILE}" ]]
@@ -15,12 +17,26 @@ then
     exit 0
 fi
 
-if [[ -z "$1" ]] || [[ ! -d "$1" ]]
+printf -v escaped_1 %q "${1}"
+
+if [[ -z ${escaped_1} ]]
 then
     usage "$0 <artefacts directory>"
+    warn "the test zero length failed for ${escaped_1}"
+    warn "you used $0 $@"
     exit ${NOARGS}
 fi
+
+if [[ ! -d "${1}" ]]
+then
+    usage "$0 <artefacts directory>"
+    warn "the test directory exists failed for ${escaped_1}"
+    warn "you used $0 $@"
+    exit ${NOARGS}
+fi
+
 workdir=$1
+printf -v escaped_workdir %q "${1}"
 
 if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]
 then

--- a/rpmpush.sh
+++ b/rpmpush.sh
@@ -30,7 +30,7 @@ fi
 if [[ ! -d "${1}" ]]
 then
     usage "$0 <artefacts directory>"
-    warn "the test directory exists failed for ${escaped_1}"
+    warn "the test directory exists failed for ${1}"
     warn "you used $0 $@"
     exit ${NOARGS}
 fi


### PR DESCRIPTION
This PR addresses the fact that currently if there is a space in the Jenkins Job name, the scripts fail rather messily. (Issue #80)

To those that were at the RHTE Satellite hackathon and would like to contribute: since this is quite invasive, I definitely need 1 review incl testing, ideally 2.

If no other testers or the PR is deemed to messy, we can fall back to testing (at the very start of the build process) if there is a space in the job name and if there is fail the build immediately.

To those that do test, these four cases should be tested at a minimum
- a Job with space(s) in the name, starting with a clean workspace
- same job name, but with a pre-existing workspace
- a Job without any separator in the name, starting with a clean workspace (to ensure nothing that works today is broke broken by e3bdf984a0b74ec4a83e9ed9663cb9c1170bfe9b)
- same job name, but with a pre-existing workspace

Also, please use the config.xml from e3bdf984a0b74ec4a83e9ed9663cb9c1170bfe9b  when testing, or at least the <buildStep class="hudson.tasks.Shell"> <command>… parts. That part is different from what we have in master today.

pcfe