### PR TITLE
hotfix for Issue #123

### DIFF
--- a/rhel-7-x86_64.cfg
+++ b/rhel-7-x86_64.cfg
@@ -5,6 +5,8 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 cpio diffutils gcc gcc-c++
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7Server'
 config_opts['use_nspawn'] = False
+config_opts['use_bootstrap'] = False
+config_opts['dnf_warning'] = False
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
- makes config work with mock-2.3-1.el7.noarch
- ensures mock does not wait for user to press enter

This is only a hotfix, I plan to rework the config to align with the new mock.